### PR TITLE
Bump bindings version to libsql-rs-v0.5.0

### DIFF
--- a/Libsql.Client/DatabaseWrapper.cs
+++ b/Libsql.Client/DatabaseWrapper.cs
@@ -106,10 +106,14 @@ namespace Libsql.Client
 
                             fixed (byte* replicaPathPtr = Encoding.UTF8.GetBytes(replicaPath))
                             {
+                                var readYourWrites = true;
+                                byte* localEncryptionKeyPtr = null;
                                 return Bindings.libsql_open_sync(
                                     replicaPathPtr,
                                     urlPtr,
                                     authTokenPtr,
+                                    *(byte*)&readYourWrites,
+                                    localEncryptionKeyPtr,
                                     dbPtr,
                                     errorCodePtr
                                 );
@@ -152,13 +156,14 @@ namespace Libsql.Client
             });
         }
 
+        // TODO: Differentiate query statements and execute statements.
         private unsafe IResultSet ExecuteStatement(Statement statement)
         {
             var error = new Error();
             var rows = new libsql_rows_t();
             int exitCode;
         
-            exitCode = Bindings.libsql_execute_stmt(statement.Stmt, &rows, &error.Ptr);
+            exitCode = Bindings.libsql_query_stmt(statement.Stmt, &rows, &error.Ptr);
             statement.Dispose();
 
             error.ThrowIfNonZero(exitCode, "Failed to execute statement");

--- a/generate-bindings.sh
+++ b/generate-bindings.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 script_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
-export LIBSQL_VERSION="0.2.2"
+export LIBSQL_RS_VERSION="0.5.0"
 bindings_dir="${script_dir}/rust-bindings"
 force=false
 
@@ -41,11 +41,11 @@ fi
 # git sparse-checkout init
 # git sparse-checkout set bindings/c bindings/wasm libsql libsql-sys
 # -----
-git fetch --quiet origin
-git checkout bdb526e
+# git fetch --quiet origin
+# git checkout fb85262
 # -----
-# git fetch --depth 1 origin tag v${LIBSQL_VERSION}
-# git reset --hard tags/v${LIBSQL_VERSION}
+git fetch --depth 1 origin tag libsql-rs-v${LIBSQL_RS_VERSION}
+git reset --hard tags/libsql-rs-v${LIBSQL_RS_VERSION}
 
 cd ..
 cargo build --release

--- a/rust-bindings/Cargo.toml
+++ b/rust-bindings/Cargo.toml
@@ -5,10 +5,14 @@ members = [
 ]
 
 [workspace.dependencies]
-rusqlite = { package = "libsql-rusqlite", path = "libsql/vendored/rusqlite", version = "0.29", default-features = false, features = [
+rusqlite = { package = "libsql-rusqlite", path = "libsql/vendored/rusqlite", version = "0.32", default-features = false, features = [
     "libsql-experimental",
     "column_decltype",
     "load_extension",
     "modern_sqlite",
     "functions",
+    "limits",
+    "hooks",
 ] }
+hyper = { version = "0.14" }
+tower = { version = "0.4.13" }

--- a/rust-bindings/csharp-bindings/Cargo.toml
+++ b/rust-bindings/csharp-bindings/Cargo.toml
@@ -6,12 +6,14 @@ edition = "2021"
 [lib]
 crate-type = ["dylib"]
 path = "../libsql/bindings/c/src/lib.rs"
+doc = false
 
 [build-dependencies]
 csbindgen = "1.2.0"
 
 [dependencies]
-sql-experimental = { path = "../libsql/bindings/c" }
+bytes = "1.5.0"
 libsql = { path = "../libsql/libsql" }
 lazy_static = "1.4.0"
 tokio = { version = "1.29.1", features = [ "rt-multi-thread" ] }
+hyper-rustls = { version = "0.25", features = ["webpki-roots"]}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    rustup
+    cmake
+  ];
+
+  shellHook = ''
+    rustup default stable
+  '';
+}


### PR DESCRIPTION
This PR changes the version of the libsql bindings to `tag/libsql-rs-v0.5.0` and makes any necessary compatibility changes to the bindings interface.